### PR TITLE
fix: do not quote stringy env variables

### DIFF
--- a/internal/provider/cached_image_resource.go
+++ b/internal/provider/cached_image_resource.go
@@ -595,14 +595,16 @@ func extractEnvbuilderFromImage(ctx context.Context, imgRef, destPath string) er
 // Check IsUnknown() first before calling String().
 type stringable interface {
 	IsUnknown() bool
+	IsNull() bool
 	String() string
 }
 
 func appendKnownEnvToList(list types.List, key string, value stringable) types.List {
-	if value.IsUnknown() {
+	if value.IsUnknown() || value.IsNull() {
 		return list
 	}
-	elem := types.StringValue(fmt.Sprintf("%s=%s", key, value.String()))
+	val := strings.Trim(value.String(), `"`)
+	elem := types.StringValue(fmt.Sprintf("%s=%s", key, val))
 	list, _ = types.ListValue(types.StringType, append(list.Elements(), elem))
 	return list
 }

--- a/internal/provider/cached_image_resource_test.go
+++ b/internal/provider/cached_image_resource_test.go
@@ -92,9 +92,9 @@ func TestAccCachedImageDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "exists", "true"),
 					resource.TestCheckResourceAttrSet("envbuilder_cached_image.test", "image"),
 					resource.TestCheckResourceAttrWith("envbuilder_cached_image.test", "image", quotedPrefix(deps.CacheRepo)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", "FOO=\"bar\""),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%q", deps.CacheRepo)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%q", deps.Repo.URL)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", "FOO=bar"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
 				),
 			},
 			// Should produce an empty plan after apply


### PR DESCRIPTION
Envbuilder will complain if you try to set `-e ENVBUILDER_VERBOSE='"true"'` which is essentially what we were doing before!