### PR TITLE
feat(internal/provider): add env_map to cached_image_resource

### DIFF
--- a/docs/resources/cached_image.md
+++ b/docs/resources/cached_image.md
@@ -48,7 +48,8 @@ The cached image resource can be used to retrieve a cached image produced by env
 
 ### Read-Only
 
-- `env` (List of String, Sensitive) Computed envbuilder configuration to be set for the container. May contain secrets.
+- `env` (List of String, Sensitive) Computed envbuilder configuration to be set for the container in the form of a list of stringss of `key=value`. May contain secrets.
+- `env_map` (Map of String, Sensitive) Computed envbuilder configuration to be set for the container in the form of a key-value map. May contain secrets.
 - `exists` (Boolean) Whether the cached image was exists or not for the given config.
 - `id` (String) Cached image identifier. This will generally be the image's SHA256 digest.
 - `image` (String) Outputs the cached image repo@digest if it exists, and builder image otherwise.

--- a/docs/resources/cached_image.md
+++ b/docs/resources/cached_image.md
@@ -48,7 +48,7 @@ The cached image resource can be used to retrieve a cached image produced by env
 
 ### Read-Only
 
-- `env` (List of String, Sensitive) Computed envbuilder configuration to be set for the container in the form of a list of stringss of `key=value`. May contain secrets.
+- `env` (List of String, Sensitive) Computed envbuilder configuration to be set for the container in the form of a list of strings of `key=value`. May contain secrets.
 - `env_map` (Map of String, Sensitive) Computed envbuilder configuration to be set for the container in the form of a key-value map. May contain secrets.
 - `exists` (Boolean) Whether the cached image was exists or not for the given config.
 - `id` (String) Cached image identifier. This will generally be the image's SHA256 digest.

--- a/internal/provider/cached_image_resource.go
+++ b/internal/provider/cached_image_resource.go
@@ -231,7 +231,7 @@ func (r *CachedImageResource) Schema(ctx context.Context, req resource.SchemaReq
 
 			// Computed "outputs".
 			"env": schema.ListAttribute{
-				MarkdownDescription: "Computed envbuilder configuration to be set for the container in the form of a list of stringss of `key=value`. May contain secrets.",
+				MarkdownDescription: "Computed envbuilder configuration to be set for the container in the form of a list of strings of `key=value`. May contain secrets.",
 				ElementType:         types.StringType,
 				Computed:            true,
 				Sensitive:           true,


### PR DESCRIPTION
This PR adds `env_map` to `cached_image_resource`. This consists of the computed env in map format, which can be useful for other providers that do not expect `KEY=VALUE` format.