### PR TITLE
fix(internal/provider): correctly override from extra_env

### DIFF
--- a/internal/provider/cached_image_resource_test.go
+++ b/internal/provider/cached_image_resource_test.go
@@ -20,8 +20,10 @@ func TestAccCachedImageResource(t *testing.T) {
 	defer cancel()
 
 	for _, tc := range []struct {
-		name  string
-		files map[string]string
+		name      string
+		files     map[string]string
+		extraEnv  map[string]string
+		assertEnv func(t *testing.T, deps testDependencies) resource.TestCheckFunc
 	}{
 		{
 			// This test case is the simplest possible case: a devcontainer.json.
@@ -30,6 +32,33 @@ func TestAccCachedImageResource(t *testing.T) {
 			name: "devcontainer only",
 			files: map[string]string{
 				".devcontainer/devcontainer.json": `{"image": "localhost:5000/test-ubuntu:latest"}`,
+			},
+			extraEnv: map[string]string{
+				"FOO":                   testEnvValue,
+				"ENVBUILDER_GIT_URL":    "https://not.the.real.git/url",
+				"ENVBUILDER_CACHE_REPO": "not-the-real-cache-repo",
+			},
+			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
+				return resource.ComposeAggregateTestCheckFunc(
+					// Check that the environment variables are set correctly.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", "ENVBUILDER_VERBOSE=true"),
+					// Check that the extra environment variables are set correctly.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", "FOO=bar\nbaz"),
+					// We should not have any other environment variables set.
+					resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.6"),
+
+					// Check that the same values are set in env_map.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
+				)
 			},
 		},
 		{
@@ -42,14 +71,84 @@ func TestAccCachedImageResource(t *testing.T) {
 				".devcontainer/Dockerfile": `FROM localhost:5000/test-ubuntu:latest
 RUN date > /date.txt`,
 			},
+			extraEnv: map[string]string{
+				"FOO":                   testEnvValue,
+				"ENVBUILDER_GIT_URL":    "https://not.the.real.git/url",
+				"ENVBUILDER_CACHE_REPO": "not-the-real-cache-repo",
+			},
+			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
+				return resource.ComposeAggregateTestCheckFunc(
+					// Check that the environment variables are set correctly.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", "ENVBUILDER_VERBOSE=true"),
+					// Check that the extra environment variables are set correctly.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", "FOO=bar\nbaz"),
+					// We should not have any other environment variables set.
+					resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.6"),
+
+					// Check that the same values are set in env_map.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
+				)
+			},
+		},
+		{
+			// This test case ensures that parameters passed via extra_env are
+			// handled correctly.
+			name: "extra_env",
+			files: map[string]string{
+				"path/to/.devcontainer/devcontainer.json": `{"build": { "dockerfile": "Dockerfile" }}`,
+				"path/to/.devcontainer/Dockerfile": `FROM localhost:5000/test-ubuntu:latest
+		RUN date > /date.txt`,
+			},
+			extraEnv: map[string]string{
+				"FOO":                               testEnvValue,
+				"ENVBUILDER_GIT_URL":                "https://not.the.real.git/url",
+				"ENVBUILDER_CACHE_REPO":             "not-the-real-cache-repo",
+				"ENVBUILDER_DEVCONTAINER_DIR":       "path/to/.devcontainer",
+				"ENVBUILDER_DEVCONTAINER_JSON_PATH": "path/to/.devcontainer/devcontainer.json",
+				"ENVBUILDER_DOCKERFILE_PATH":        "path/to/.devcontainer/Dockerfile",
+			},
+			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
+				return resource.ComposeAggregateTestCheckFunc(
+					// Check that the environment variables are set correctly.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_DEVCONTAINER_DIR=%s", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_DIR"])),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_DEVCONTAINER_JSON_PATH=%s", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_JSON_PATH"])),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", fmt.Sprintf("ENVBUILDER_DOCKERFILE_PATH=%s", deps.ExtraEnv["ENVBUILDER_DOCKERFILE_PATH"])),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.6", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.7", "ENVBUILDER_VERBOSE=true"),
+					// Check that the extra environment variables are set correctly.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.8", "FOO=bar\nbaz"),
+					// We should not have any other environment variables set.
+					resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.9"),
+
+					// Check that the same values are set in env_map.
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_DEVCONTAINER_DIR", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_DIR"]),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_DEVCONTAINER_JSON_PATH", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_JSON_PATH"]),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_DOCKERFILE_PATH", deps.ExtraEnv["ENVBUILDER_DOCKERFILE_PATH"]),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
+					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
+				)
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			//nolint: paralleltest
-			deps := setup(ctx, t, tc.files)
-			deps.ExtraEnv["FOO"] = testEnvValue
-			deps.ExtraEnv["ENVBUILDER_GIT_URL"] = "https://not.the.real.git/url"
-			deps.ExtraEnv["ENVBUILDER_CACHE_REPO"] = "not-the-real-cache-repo"
+			deps := setup(ctx, t, tc.extraEnv, tc.files)
 
 			resource.Test(t, resource.TestCase{
 				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -78,7 +177,7 @@ RUN date > /date.txt`,
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "git_password"),
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "cache_ttl_days"),
 							// Environment variables
-							assertEnv(t, deps),
+							tc.assertEnv(t, deps),
 						),
 						ExpectNonEmptyPlan: true, // TODO: check the plan.
 					},
@@ -100,7 +199,7 @@ RUN date > /date.txt`,
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "git_password"),
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "cache_ttl_days"),
 							// Environment variables
-							assertEnv(t, deps),
+							tc.assertEnv(t, deps),
 						),
 						ExpectNonEmptyPlan: true, // TODO: check the plan.
 					},
@@ -125,7 +224,7 @@ RUN date > /date.txt`,
 							resource.TestCheckResourceAttrSet("envbuilder_cached_image.test", "image"),
 							resource.TestCheckResourceAttrWith("envbuilder_cached_image.test", "image", quotedPrefix(deps.CacheRepo)),
 							// Environment variables
-							assertEnv(t, deps),
+							tc.assertEnv(t, deps),
 						),
 					},
 					// 5) Should produce an empty plan after apply

--- a/internal/provider/cached_image_resource_test.go
+++ b/internal/provider/cached_image_resource_test.go
@@ -40,24 +40,14 @@ func TestAccCachedImageResource(t *testing.T) {
 			},
 			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
 				return resource.ComposeAggregateTestCheckFunc(
-					// Check that the environment variables are set correctly.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", "ENVBUILDER_VERBOSE=true"),
-					// Check that the extra environment variables are set correctly.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", "FOO=bar\nbaz"),
-					// We should not have any other environment variables set.
-					resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.6"),
-
-					// Check that the same values are set in env_map.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
+					assertEnv(t,
+						"ENVBUILDER_CACHE_REPO", deps.CacheRepo,
+						"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key,
+						"ENVBUILDER_GIT_URL", deps.Repo.URL,
+						"ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true",
+						"ENVBUILDER_VERBOSE", "true",
+						"FOO", "bar\nbaz",
+					),
 				)
 			},
 		},
@@ -78,24 +68,14 @@ RUN date > /date.txt`,
 			},
 			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
 				return resource.ComposeAggregateTestCheckFunc(
-					// Check that the environment variables are set correctly.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", "ENVBUILDER_VERBOSE=true"),
-					// Check that the extra environment variables are set correctly.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", "FOO=bar\nbaz"),
-					// We should not have any other environment variables set.
-					resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.6"),
-
-					// Check that the same values are set in env_map.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
+					assertEnv(t,
+						"ENVBUILDER_CACHE_REPO", deps.CacheRepo,
+						"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key,
+						"ENVBUILDER_GIT_URL", deps.Repo.URL,
+						"ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true",
+						"ENVBUILDER_VERBOSE", "true",
+						"FOO", "bar\nbaz",
+					),
 				)
 			},
 		},
@@ -118,30 +98,17 @@ RUN date > /date.txt`,
 			},
 			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
 				return resource.ComposeAggregateTestCheckFunc(
-					// Check that the environment variables are set correctly.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_DEVCONTAINER_DIR=%s", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_DIR"])),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_DEVCONTAINER_JSON_PATH=%s", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_JSON_PATH"])),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", fmt.Sprintf("ENVBUILDER_DOCKERFILE_PATH=%s", deps.ExtraEnv["ENVBUILDER_DOCKERFILE_PATH"])),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.6", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.7", "ENVBUILDER_VERBOSE=true"),
-					// Check that the extra environment variables are set correctly.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.8", "FOO=bar\nbaz"),
-					// We should not have any other environment variables set.
-					resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.9"),
-
-					// Check that the same values are set in env_map.
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_DEVCONTAINER_DIR", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_DIR"]),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_DEVCONTAINER_JSON_PATH", deps.ExtraEnv["ENVBUILDER_DEVCONTAINER_JSON_PATH"]),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_DOCKERFILE_PATH", deps.ExtraEnv["ENVBUILDER_DOCKERFILE_PATH"]),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
-					resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
+					assertEnv(t,
+						"ENVBUILDER_CACHE_REPO", deps.CacheRepo,
+						"ENVBUILDER_DEVCONTAINER_DIR", "path/to/.devcontainer",
+						"ENVBUILDER_DEVCONTAINER_JSON_PATH", "path/to/.devcontainer/devcontainer.json",
+						"ENVBUILDER_DOCKERFILE_PATH", "path/to/.devcontainer/Dockerfile",
+						"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key,
+						"ENVBUILDER_GIT_URL", deps.Repo.URL,
+						"ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true",
+						"ENVBUILDER_VERBOSE", "true",
+						"FOO", "bar\nbaz",
+					),
 				)
 			},
 		},
@@ -170,7 +137,6 @@ RUN date > /date.txt`,
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "image", deps.BuilderImage),
 							// Inputs should still be present.
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "cache_repo", deps.CacheRepo),
-							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "extra_env.FOO", "bar\nbaz"),
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "git_url", deps.Repo.URL),
 							// Should be empty
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "git_username"),
@@ -192,7 +158,6 @@ RUN date > /date.txt`,
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "image", deps.BuilderImage),
 							// Inputs should still be present.
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "cache_repo", deps.CacheRepo),
-							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "extra_env.FOO", "bar\nbaz"),
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "git_url", deps.Repo.URL),
 							// Should be empty
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "git_username"),
@@ -212,7 +177,6 @@ RUN date > /date.txt`,
 						Check: resource.ComposeAggregateTestCheckFunc(
 							// Inputs should still be present.
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "cache_repo", deps.CacheRepo),
-							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "extra_env.FOO", "bar\nbaz"),
 							resource.TestCheckResourceAttr("envbuilder_cached_image.test", "git_url", deps.Repo.URL),
 							// Should be empty
 							resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "git_username"),
@@ -243,28 +207,31 @@ RUN date > /date.txt`,
 	}
 }
 
-// assertEnv is a test helper that checks the environment variables set on the
-// cached image resource based on the provided test dependencies.
-func assertEnv(t *testing.T, deps testDependencies) resource.TestCheckFunc {
+// assertEnv is a test helper that checks the environment variables, in order,
+// on both the env and env_map attributes of the cached image resource.
+func assertEnv(t *testing.T, kvs ...string) resource.TestCheckFunc {
 	t.Helper()
-	return resource.ComposeAggregateTestCheckFunc(
-		// Check that the environment variables are set correctly.
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.0", fmt.Sprintf("ENVBUILDER_CACHE_REPO=%s", deps.CacheRepo)),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.1", fmt.Sprintf("ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH=%s", deps.Repo.Key)),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.2", fmt.Sprintf("ENVBUILDER_GIT_URL=%s", deps.Repo.URL)),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.3", "ENVBUILDER_REMOTE_REPO_BUILD_MODE=true"),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.4", "ENVBUILDER_VERBOSE=true"),
-		// Check that the extra environment variables are set correctly.
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env.5", "FOO=bar\nbaz"),
-		// We should not have any other environment variables set.
-		resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", "env.6"),
+	if len(kvs)%2 != 0 {
+		t.Fatalf("assertEnv: expected an even number of key-value pairs, got %d", len(kvs))
+	}
 
-		// Check that the same values are set in env_map.
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_CACHE_REPO", deps.CacheRepo),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_GIT_URL", deps.Repo.URL),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true"),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.ENVBUILDER_VERBOSE", "true"),
-		resource.TestCheckResourceAttr("envbuilder_cached_image.test", "env_map.FOO", "bar\nbaz"),
-	)
+	funcs := make([]resource.TestCheckFunc, 0)
+	for i := 0; i < len(kvs); i += 2 {
+		resKey := fmt.Sprintf("env.%d", len(funcs))
+		resVal := fmt.Sprintf("%s=%s", kvs[i], kvs[i+1])
+		fn := resource.TestCheckResourceAttr("envbuilder_cached_image.test", resKey, resVal)
+		funcs = append(funcs, fn)
+	}
+
+	lastKey := fmt.Sprintf("env.%d", len(funcs))
+	lastFn := resource.TestCheckNoResourceAttr("envbuilder_cached_image.test", lastKey)
+	funcs = append(funcs, lastFn)
+
+	for i := 0; i < len(kvs); i += 2 {
+		resKey := fmt.Sprintf("env_map.%s", kvs[i])
+		fn := resource.TestCheckResourceAttr("envbuilder_cached_image.test", resKey, kvs[i+1])
+		funcs = append(funcs, fn)
+	}
+
+	return resource.ComposeAggregateTestCheckFunc(funcs...)
 }

--- a/internal/provider/provider_internal_test.go
+++ b/internal/provider/provider_internal_test.go
@@ -1,0 +1,359 @@
+package provider
+
+import (
+	"testing"
+
+	eboptions "github.com/coder/envbuilder/options"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_optionsFromDataModel(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                  string
+		data                  CachedImageResourceModel
+		expectOpts            eboptions.Options
+		expectNumErrorDiags   int
+		expectNumWarningDiags int
+	}{
+		{
+			name: "required only",
+			data: CachedImageResourceModel{
+				BuilderImage: basetypes.NewStringValue("envbuilder:latest"),
+				CacheRepo:    basetypes.NewStringValue("localhost:5000/cache"),
+				GitURL:       basetypes.NewStringValue("git@git.local/devcontainer.git"),
+			},
+			expectOpts: eboptions.Options{
+				CacheRepo:           "localhost:5000/cache",
+				GitURL:              "git@git.local/devcontainer.git",
+				RemoteRepoBuildMode: true,
+			},
+		},
+		{
+			name: "all options without extra_env",
+			data: CachedImageResourceModel{
+				BuilderImage:         basetypes.NewStringValue("envbuilder:latest"),
+				CacheRepo:            basetypes.NewStringValue("localhost:5000/cache"),
+				GitURL:               basetypes.NewStringValue("git@git.local/devcontainer.git"),
+				BaseImageCacheDir:    basetypes.NewStringValue("/tmp/cache"),
+				BuildContextPath:     basetypes.NewStringValue("."),
+				CacheTTLDays:         basetypes.NewInt64Value(7),
+				DevcontainerDir:      basetypes.NewStringValue(".devcontainer"),
+				DevcontainerJSONPath: basetypes.NewStringValue(".devcontainer/devcontainer.json"),
+				DockerfilePath:       basetypes.NewStringValue("Dockerfile"),
+				DockerConfigBase64:   basetypes.NewStringValue("some base64"),
+				ExitOnBuildFailure:   basetypes.NewBoolValue(true),
+				// ExtraEnv: map[string]basetypes.Value{},
+				FallbackImage:        basetypes.NewStringValue("fallback"),
+				GitCloneDepth:        basetypes.NewInt64Value(1),
+				GitCloneSingleBranch: basetypes.NewBoolValue(true),
+				GitHTTPProxyURL:      basetypes.NewStringValue("http://proxy"),
+				GitPassword:          basetypes.NewStringValue("password"),
+				GitSSHPrivateKeyPath: basetypes.NewStringValue("/tmp/id_rsa"),
+				GitUsername:          basetypes.NewStringValue("user"),
+				IgnorePaths:          listValue("ignore", "paths"),
+				Insecure:             basetypes.NewBoolValue(true),
+				RemoteRepoBuildMode:  basetypes.NewBoolValue(false),
+				SSLCertBase64:        basetypes.NewStringValue("cert"),
+				Verbose:              basetypes.NewBoolValue(true),
+				WorkspaceFolder:      basetypes.NewStringValue("workspace"),
+			},
+			expectOpts: eboptions.Options{
+				CacheRepo:            "localhost:5000/cache",
+				GitURL:               "git@git.local/devcontainer.git",
+				BaseImageCacheDir:    "/tmp/cache",
+				BuildContextPath:     ".",
+				CacheTTLDays:         7,
+				DevcontainerDir:      ".devcontainer",
+				DevcontainerJSONPath: ".devcontainer/devcontainer.json",
+				DockerfilePath:       "Dockerfile",
+				DockerConfigBase64:   "some base64",
+				ExitOnBuildFailure:   true,
+				FallbackImage:        "fallback",
+				GitCloneDepth:        1,
+				GitCloneSingleBranch: true,
+				GitHTTPProxyURL:      "http://proxy",
+				GitPassword:          "password",
+				GitSSHPrivateKeyPath: "/tmp/id_rsa",
+				GitUsername:          "user",
+				IgnorePaths:          []string{"ignore", "paths"},
+				Insecure:             true,
+				RemoteRepoBuildMode:  false,
+				SSLCertBase64:        "cert",
+				Verbose:              true,
+				WorkspaceFolder:      "workspace",
+			},
+		},
+		{
+			name: "extra env override",
+			data: CachedImageResourceModel{
+				BuilderImage: basetypes.NewStringValue("envbuilder:latest"),
+				CacheRepo:    basetypes.NewStringValue("localhost:5000/cache"),
+				GitURL:       basetypes.NewStringValue("git@git.local/devcontainer.git"),
+				ExtraEnv: extraEnvMap(t,
+					"CODER_AGENT_TOKEN", "token",
+					"CODER_AGENT_URL", "http://coder",
+					"FOO", "bar",
+				),
+			},
+			expectOpts: eboptions.Options{
+				CacheRepo:           "localhost:5000/cache",
+				GitURL:              "git@git.local/devcontainer.git",
+				RemoteRepoBuildMode: true,
+				CoderAgentToken:     "token",
+				CoderAgentURL:       "http://coder",
+			},
+		},
+		{
+			name: "extra_env override warnings",
+			data: CachedImageResourceModel{
+				BuilderImage:         basetypes.NewStringValue("envbuilder:latest"),
+				CacheRepo:            basetypes.NewStringValue("localhost:5000/cache"),
+				GitURL:               basetypes.NewStringValue("git@git.local/devcontainer.git"),
+				BaseImageCacheDir:    basetypes.NewStringValue("/tmp/cache"),
+				BuildContextPath:     basetypes.NewStringValue("."),
+				CacheTTLDays:         basetypes.NewInt64Value(7),
+				DevcontainerDir:      basetypes.NewStringValue(".devcontainer"),
+				DevcontainerJSONPath: basetypes.NewStringValue(".devcontainer/devcontainer.json"),
+				DockerfilePath:       basetypes.NewStringValue("Dockerfile"),
+				DockerConfigBase64:   basetypes.NewStringValue("some base64"),
+				ExitOnBuildFailure:   basetypes.NewBoolValue(true),
+				// ExtraEnv: map[string]basetypes.Value{},
+				FallbackImage:        basetypes.NewStringValue("fallback"),
+				GitCloneDepth:        basetypes.NewInt64Value(1),
+				GitCloneSingleBranch: basetypes.NewBoolValue(true),
+				GitHTTPProxyURL:      basetypes.NewStringValue("http://proxy"),
+				GitPassword:          basetypes.NewStringValue("password"),
+				GitSSHPrivateKeyPath: basetypes.NewStringValue("/tmp/id_rsa"),
+				GitUsername:          basetypes.NewStringValue("user"),
+				IgnorePaths:          listValue("ignore", "paths"),
+				Insecure:             basetypes.NewBoolValue(true),
+				RemoteRepoBuildMode:  basetypes.NewBoolValue(false),
+				SSLCertBase64:        basetypes.NewStringValue("cert"),
+				Verbose:              basetypes.NewBoolValue(true),
+				WorkspaceFolder:      basetypes.NewStringValue("workspace"),
+				ExtraEnv: extraEnvMap(t,
+					"ENVBUILDER_CACHE_REPO", "override",
+					"ENVBUILDER_GIT_URL", "override",
+					"ENVBUILDER_BASE_IMAGE_CACHE_DIR", "override",
+					"ENVBUILDER_BUILD_CONTEXT_PATH", "override",
+					"ENVBUILDER_CACHE_TTL_DAYS", "8",
+					"ENVBUILDER_DEVCONTAINER_DIR", "override",
+					"ENVBUILDER_DEVCONTAINER_JSON_PATH", "override",
+					"ENVBUILDER_DOCKERFILE_PATH", "override",
+					"ENVBUILDER_DOCKER_CONFIG_BASE64", "override",
+					"ENVBUILDER_EXIT_ON_BUILD_FAILURE", "false",
+					"ENVBUILDER_FALLBACK_IMAGE", "override",
+					"ENVBUILDER_GIT_CLONE_DEPTH", "2",
+					"ENVBUILDER_GIT_CLONE_SINGLE_BRANCH", "false",
+					"ENVBUILDER_GIT_HTTP_PROXY_URL", "override",
+					"ENVBUILDER_GIT_PASSWORD", "override",
+					"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", "override",
+					"ENVBUILDER_GIT_USERNAME", "override",
+					"ENVBUILDER_IGNORE_PATHS", "override",
+					"ENVBUILDER_INSECURE", "false",
+					"ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true",
+					"ENVBUILDER_SSL_CERT_BASE64", "override",
+					"ENVBUILDER_VERBOSE", "false",
+					"ENVBUILDER_WORKSPACE_FOLDER", "override",
+					"FOO", "bar",
+				),
+			},
+			expectOpts: eboptions.Options{
+				// not overridden
+				CacheRepo: "localhost:5000/cache",
+				GitURL:    "git@git.local/devcontainer.git",
+				// overridden
+				BaseImageCacheDir:    "override",
+				BuildContextPath:     "override",
+				CacheTTLDays:         8,
+				DevcontainerDir:      "override",
+				DevcontainerJSONPath: "override",
+				DockerfilePath:       "override",
+				DockerConfigBase64:   "override",
+				ExitOnBuildFailure:   false,
+				FallbackImage:        "override",
+				GitCloneDepth:        2,
+				GitCloneSingleBranch: false,
+				GitHTTPProxyURL:      "override",
+				GitPassword:          "override",
+				GitSSHPrivateKeyPath: "override",
+				GitUsername:          "override",
+				IgnorePaths:          []string{"override"},
+				Insecure:             false,
+				RemoteRepoBuildMode:  true,
+				SSLCertBase64:        "override",
+				Verbose:              false,
+				WorkspaceFolder:      "override",
+			},
+			expectNumWarningDiags: 23,
+		},
+		{
+			name: "extra_env override errors",
+			data: CachedImageResourceModel{
+				BuilderImage: basetypes.NewStringValue("envbuilder:latest"),
+				CacheRepo:    basetypes.NewStringValue("localhost:5000/cache"),
+				GitURL:       basetypes.NewStringValue("git@git.local/devcontainer.git"),
+				ExtraEnv: extraEnvMap(t,
+					"ENVBUILDER_CACHE_TTL_DAYS", "not a number",
+					"ENVBUILDER_VERBOSE", "not a bool",
+					"FOO", "bar",
+				),
+			},
+			expectOpts: eboptions.Options{
+				// not overridden
+				CacheRepo:           "localhost:5000/cache",
+				GitURL:              "git@git.local/devcontainer.git",
+				RemoteRepoBuildMode: true,
+			},
+			expectNumErrorDiags: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual, diags := optionsFromDataModel(tc.data)
+			assert.Equal(t, tc.expectNumErrorDiags, diags.ErrorsCount())
+			assert.Equal(t, tc.expectNumWarningDiags, diags.WarningsCount())
+			assert.EqualValues(t, tc.expectOpts, actual)
+		})
+	}
+}
+
+func Test_computeEnvFromOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		opts      eboptions.Options
+		extraEnv  map[string]string
+		expectEnv map[string]string
+	}{
+		{
+			name:      "empty",
+			opts:      eboptions.Options{},
+			expectEnv: map[string]string{},
+		},
+		{
+			name: "all options",
+			opts: eboptions.Options{
+				BaseImageCacheDir:    "string",
+				BinaryPath:           "string",
+				BuildContextPath:     "string",
+				CacheRepo:            "string",
+				CacheTTLDays:         1,
+				CoderAgentSubsystem:  []string{"one", "two"},
+				CoderAgentToken:      "string",
+				CoderAgentURL:        "string",
+				DevcontainerDir:      "string",
+				DevcontainerJSONPath: "string",
+				DockerConfigBase64:   "string",
+				DockerfilePath:       "string",
+				ExitOnBuildFailure:   true,
+				ExportEnvFile:        "string",
+				FallbackImage:        "string",
+				ForceSafe:            true,
+				GetCachedImage:       true,
+				GitCloneDepth:        1,
+				GitCloneSingleBranch: true,
+				GitHTTPProxyURL:      "string",
+				GitPassword:          "string",
+				GitSSHPrivateKeyPath: "string",
+				GitURL:               "string",
+				GitUsername:          "string",
+				IgnorePaths:          []string{"one", "two"},
+				InitArgs:             "string",
+				InitCommand:          "string",
+				InitScript:           "string",
+				Insecure:             true,
+				LayerCacheDir:        "string",
+				PostStartScriptPath:  "string",
+				PushImage:            true,
+				RemoteRepoBuildMode:  true,
+				RemoteRepoDir:        "string",
+				SetupScript:          "string",
+				SkipRebuild:          true,
+				SSLCertBase64:        "string",
+				Verbose:              true,
+				WorkspaceFolder:      "string",
+			},
+			extraEnv: map[string]string{
+				"ENVBUILDER_SOMETHING": "string", // should be ignored
+				"FOO":                  "bar",    // should be included
+			},
+			expectEnv: map[string]string{
+				"CODER_AGENT_SUBSYSTEM":               "one,two",
+				"CODER_AGENT_TOKEN":                   "string",
+				"CODER_AGENT_URL":                     "string",
+				"ENVBUILDER_BASE_IMAGE_CACHE_DIR":     "string",
+				"ENVBUILDER_BINARY_PATH":              "string",
+				"ENVBUILDER_BUILD_CONTEXT_PATH":       "string",
+				"ENVBUILDER_CACHE_REPO":               "string",
+				"ENVBUILDER_CACHE_TTL_DAYS":           "1",
+				"ENVBUILDER_DEVCONTAINER_DIR":         "string",
+				"ENVBUILDER_DEVCONTAINER_JSON_PATH":   "string",
+				"ENVBUILDER_DOCKER_CONFIG_BASE64":     "string",
+				"ENVBUILDER_DOCKERFILE_PATH":          "string",
+				"ENVBUILDER_EXIT_ON_BUILD_FAILURE":    "true",
+				"ENVBUILDER_EXPORT_ENV_FILE":          "string",
+				"ENVBUILDER_FALLBACK_IMAGE":           "string",
+				"ENVBUILDER_FORCE_SAFE":               "true",
+				"ENVBUILDER_GET_CACHED_IMAGE":         "true",
+				"ENVBUILDER_GIT_CLONE_DEPTH":          "1",
+				"ENVBUILDER_GIT_CLONE_SINGLE_BRANCH":  "true",
+				"ENVBUILDER_GIT_HTTP_PROXY_URL":       "string",
+				"ENVBUILDER_GIT_PASSWORD":             "string",
+				"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH": "string",
+				"ENVBUILDER_GIT_URL":                  "string",
+				"ENVBUILDER_GIT_USERNAME":             "string",
+				"ENVBUILDER_IGNORE_PATHS":             "one,two",
+				"ENVBUILDER_INIT_ARGS":                "string",
+				"ENVBUILDER_INIT_COMMAND":             "string",
+				"ENVBUILDER_INIT_SCRIPT":              "string",
+				"ENVBUILDER_INSECURE":                 "true",
+				"ENVBUILDER_LAYER_CACHE_DIR":          "string",
+				"ENVBUILDER_POST_START_SCRIPT_PATH":   "string",
+				"ENVBUILDER_PUSH_IMAGE":               "true",
+				"ENVBUILDER_REMOTE_REPO_BUILD_MODE":   "true",
+				"ENVBUILDER_REMOTE_REPO_DIR":          "string",
+				"ENVBUILDER_SETUP_SCRIPT":             "string",
+				"ENVBUILDER_SKIP_REBUILD":             "true",
+				"ENVBUILDER_SSL_CERT_BASE64":          "string",
+				"ENVBUILDER_VERBOSE":                  "true",
+				"ENVBUILDER_WORKSPACE_FOLDER":         "string",
+				"FOO":                                 "bar",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.extraEnv == nil {
+				tc.extraEnv = map[string]string{}
+			}
+			actual := computeEnvFromOptions(tc.opts, tc.extraEnv)
+			assert.EqualValues(t, tc.expectEnv, actual)
+		})
+	}
+}
+
+func listValue(vs ...string) basetypes.ListValue {
+	vals := make([]attr.Value, len(vs))
+	for i, s := range vs {
+		vals[i] = basetypes.NewStringValue(s)
+	}
+	return basetypes.NewListValueMust(basetypes.StringType{}, vals)
+}
+
+func extraEnvMap(t *testing.T, kvs ...string) basetypes.MapValue {
+	t.Helper()
+	if len(kvs)%2 != 0 {
+		t.Fatalf("extraEnvMap: expected even number of key-value pairs, got %d", len(kvs))
+	}
+	vals := make(map[string]attr.Value)
+	for i := 0; i < len(kvs); i += 2 {
+		vals[kvs[i]] = basetypes.NewStringValue(kvs[i+1])
+	}
+	return basetypes.NewMapValueMust(basetypes.StringType{}, vals)
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -49,14 +49,14 @@ func (d *testDependencies) Config(t testing.TB) string {
 resource "envbuilder_cached_image" "test" {
   builder_image            = {{ quote .BuilderImage }}
 	cache_repo               = {{ quote .CacheRepo }}
+	git_url                  = {{ quote .Repo.URL }}
 	extra_env                = {
+		"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH": {{ quote .Repo.Key }}
+		"ENVBUILDER_VERBOSE": true
 	{{ range $k, $v := .ExtraEnv }}
 		{{ quote $k }}: {{ quote $v }}
 	{{ end }}
 	}
-	git_url                  = {{ quote .Repo.URL }}
-	git_ssh_private_key_path = {{ quote .Repo.Key }}
-	verbose                  = true
 }`
 
 	fm := template.FuncMap{"quote": quote}


### PR DESCRIPTION
Relates to https://github.com/coder/terraform-provider-envbuilder/issues/43

Our previous logic did not pass options from `extra_env` to `envbuilder.RunCacheProbe`.
This fixes the logic and adds more comprehensive tests around the overriding.

Before, we were setting environment variables directly from the data source model but not applying them properly to envbuilder.Options
The new overall flow is:
- Data source model is converted to an envbuilder options struct
- `extra_env` is applied to envbuilder options struct
- Computed env is generated from envbuilder options struct