### PR TITLE
fix: update envbuilder to include kaniko cache fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/coder/terraform-provider-envbuilder
 go 1.22.4
 
 // We use our own Kaniko fork.
-replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240830141327-f307586e3dca
+replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240924160037-1e6bd4e19fc6
 
 // Required to import codersdk due to gvisor dependency.
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20240702054557-aa558fbe5374
 
 require (
 	github.com/GoogleContainerTools/kaniko v1.9.2
-	github.com/coder/envbuilder v1.0.0-rc.0.0.20240910082823-b7781d802f88
+	github.com/coder/envbuilder v1.0.0-rc.0.0.20240924170424-29636303d05f
 	github.com/coder/serpent v0.8.0
 	github.com/docker/docker v26.1.5+incompatible
 	github.com/gliderlabs/ssh v0.3.7

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/coder/terraform-provider-envbuilder
 go 1.22.4
 
 // We use our own Kaniko fork.
-replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240924160037-1e6bd4e19fc6
+replace github.com/GoogleContainerTools/kaniko => github.com/coder/kaniko v0.0.0-20240925122543-caa18967f374
 
 // Required to import codersdk due to gvisor dependency.
 replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20240702054557-aa558fbe5374
 
 require (
 	github.com/GoogleContainerTools/kaniko v1.9.2
-	github.com/coder/envbuilder v1.0.0-rc.0.0.20240924170424-29636303d05f
+	github.com/coder/envbuilder v1.0.0-rc.0.0.20240925123650-9c315aabfaef
 	github.com/coder/serpent v0.8.0
 	github.com/docker/docker v26.1.5+incompatible
 	github.com/gliderlabs/ssh v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,12 @@ github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352 h1:L/EjCuZxs5tOc
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352/go.mod h1:P1KoQSgnKEAG6Mnd3YlGzAophty+yKA9VV48LpfNRvo=
 github.com/coder/envbuilder v1.0.0-rc.0.0.20240924170424-29636303d05f h1:1KdB2Jbo+zLuG+R08/By1BIeHBcKXiOqv95wZ5+Ewks=
 github.com/coder/envbuilder v1.0.0-rc.0.0.20240924170424-29636303d05f/go.mod h1:ju1iDjfVSUQS3tlaIItlRo8UwYbGN5KvOdnbOzlD/6I=
+github.com/coder/envbuilder v1.0.0-rc.0.0.20240925123650-9c315aabfaef h1:l9mQMoHNl7P2tiahwM2zkUCdWsjSoLsUDn30Ndgsx0Y=
+github.com/coder/envbuilder v1.0.0-rc.0.0.20240925123650-9c315aabfaef/go.mod h1:1Qn60Fx3oGZlwmRfTNkrGxrQJsEZ7XIUUPgzil2lte8=
 github.com/coder/kaniko v0.0.0-20240924160037-1e6bd4e19fc6 h1:vLlV6P0abwoOeaBwkqQxB31ZzMv483UQLhQuPvXbvRM=
 github.com/coder/kaniko v0.0.0-20240924160037-1e6bd4e19fc6/go.mod h1:XoTDIhNF0Ll4tLmRYdOn31udU9w5zFrY2PME/crSRCA=
+github.com/coder/kaniko v0.0.0-20240925122543-caa18967f374 h1:/cyXf0vTSwFh7evQqeWHXXl14aRfC4CsNIYxOenJytQ=
+github.com/coder/kaniko v0.0.0-20240925122543-caa18967f374/go.mod h1:XoTDIhNF0Ll4tLmRYdOn31udU9w5zFrY2PME/crSRCA=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=

--- a/go.sum
+++ b/go.sum
@@ -186,10 +186,10 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352 h1:L/EjCuZxs5tOcqqCaASj/nu65TRYEFcTt8qRQfHZXX0=
 github.com/coder/coder/v2 v2.10.1-0.20240704130443-c2d44d16a352/go.mod h1:P1KoQSgnKEAG6Mnd3YlGzAophty+yKA9VV48LpfNRvo=
-github.com/coder/envbuilder v1.0.0-rc.0.0.20240910082823-b7781d802f88 h1:eXOILD2tWepnV1r7XZalBX0yC4NJMnpf6OP1nF8O2Ak=
-github.com/coder/envbuilder v1.0.0-rc.0.0.20240910082823-b7781d802f88/go.mod h1:krXpDmUsORgNNdvBe6tnwWCGGDLhabom1UUqAZq9+v0=
-github.com/coder/kaniko v0.0.0-20240830141327-f307586e3dca h1:PrcSWrllqipTrtet50a3VyAJEQmjziIZyhpy0bsC6o0=
-github.com/coder/kaniko v0.0.0-20240830141327-f307586e3dca/go.mod h1:XoTDIhNF0Ll4tLmRYdOn31udU9w5zFrY2PME/crSRCA=
+github.com/coder/envbuilder v1.0.0-rc.0.0.20240924170424-29636303d05f h1:1KdB2Jbo+zLuG+R08/By1BIeHBcKXiOqv95wZ5+Ewks=
+github.com/coder/envbuilder v1.0.0-rc.0.0.20240924170424-29636303d05f/go.mod h1:ju1iDjfVSUQS3tlaIItlRo8UwYbGN5KvOdnbOzlD/6I=
+github.com/coder/kaniko v0.0.0-20240924160037-1e6bd4e19fc6 h1:vLlV6P0abwoOeaBwkqQxB31ZzMv483UQLhQuPvXbvRM=
+github.com/coder/kaniko v0.0.0-20240924160037-1e6bd4e19fc6/go.mod h1:XoTDIhNF0Ll4tLmRYdOn31udU9w5zFrY2PME/crSRCA=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=

--- a/internal/provider/cached_image_resource_test.go
+++ b/internal/provider/cached_image_resource_test.go
@@ -168,7 +168,46 @@ RUN date > /date.txt`,
 			files: map[string]string{
 				"Dockerfile": `
 		FROM localhost:5000/test-ubuntu:latest
-		COPY date.txt /date.txt`,
+		COPY date.txt /date.txt
+		RUN chown 1000:1000 /date.txt`,
+				"date.txt": fmt.Sprintf("%d", time.Now().Unix()),
+			},
+			extraEnv: map[string]string{
+				"CODER_AGENT_TOKEN":          "some-token",
+				"CODER_AGENT_URL":            "https://coder.example.com",
+				"FOO":                        testEnvValue,
+				"ENVBUILDER_GIT_URL":         "https://not.the.real.git/url",
+				"ENVBUILDER_CACHE_REPO":      "not-the-real-cache-repo",
+				"ENVBUILDER_DOCKERFILE_PATH": "Dockerfile",
+			},
+			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
+				return resource.ComposeAggregateTestCheckFunc(
+					assertEnv(t,
+						"CODER_AGENT_TOKEN", "some-token",
+						"CODER_AGENT_URL", "https://coder.example.com",
+						"ENVBUILDER_CACHE_REPO", deps.CacheRepo,
+						"ENVBUILDER_DOCKERFILE_PATH", "Dockerfile",
+						"ENVBUILDER_DOCKER_CONFIG_BASE64", deps.DockerConfigBase64,
+						"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key,
+						"ENVBUILDER_GIT_URL", deps.Repo.URL,
+						"ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true",
+						"ENVBUILDER_VERBOSE", "true",
+						"FOO", "bar\nbaz",
+					),
+				)
+			},
+		},
+		{
+			// Same as above, except for multi-stage build.
+			name: "copy_perms_multistage",
+			files: map[string]string{
+				"Dockerfile": `
+		FROM localhost:5000/test-ubuntu:latest AS a
+		COPY date.txt /date.txt
+		RUN chown 1000:1000 /date.txt
+		FROM localhost:5000/test-ubuntu:latest
+		COPY --from=a /date.txt /date.txt
+		RUN chown 1001:1001 /date.txt`,
 				"date.txt": fmt.Sprintf("%d", time.Now().Unix()),
 			},
 			extraEnv: map[string]string{

--- a/internal/provider/cached_image_resource_test.go
+++ b/internal/provider/cached_image_resource_test.go
@@ -161,6 +161,41 @@ RUN date > /date.txt`,
 				)
 			},
 		},
+		{
+			// This tests correct handling of the difference in permissions between
+			// the provider and the image when running a COPY instruction.
+			name: "copy_perms",
+			files: map[string]string{
+				"Dockerfile": `
+		FROM localhost:5000/test-ubuntu:latest
+		COPY date.txt /date.txt`,
+				"date.txt": fmt.Sprintf("%d", time.Now().Unix()),
+			},
+			extraEnv: map[string]string{
+				"CODER_AGENT_TOKEN":          "some-token",
+				"CODER_AGENT_URL":            "https://coder.example.com",
+				"FOO":                        testEnvValue,
+				"ENVBUILDER_GIT_URL":         "https://not.the.real.git/url",
+				"ENVBUILDER_CACHE_REPO":      "not-the-real-cache-repo",
+				"ENVBUILDER_DOCKERFILE_PATH": "Dockerfile",
+			},
+			assertEnv: func(t *testing.T, deps testDependencies) resource.TestCheckFunc {
+				return resource.ComposeAggregateTestCheckFunc(
+					assertEnv(t,
+						"CODER_AGENT_TOKEN", "some-token",
+						"CODER_AGENT_URL", "https://coder.example.com",
+						"ENVBUILDER_CACHE_REPO", deps.CacheRepo,
+						"ENVBUILDER_DOCKERFILE_PATH", "Dockerfile",
+						"ENVBUILDER_DOCKER_CONFIG_BASE64", deps.DockerConfigBase64,
+						"ENVBUILDER_GIT_SSH_PRIVATE_KEY_PATH", deps.Repo.Key,
+						"ENVBUILDER_GIT_URL", deps.Repo.URL,
+						"ENVBUILDER_REMOTE_REPO_BUILD_MODE", "true",
+						"ENVBUILDER_VERBOSE", "true",
+						"FOO", "bar\nbaz",
+					),
+				)
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			//nolint: paralleltest


### PR DESCRIPTION
Relates to https://github.com/coder/terraform-provider-envbuilder/issues/43

Updates envbuilder to version including kaniko caching ownership fix https://github.com/coder/kaniko/pull/29

Also adds a test to demonstrate behaviour.